### PR TITLE
Fix domain event timestamp and test data

### DIFF
--- a/src/Application/Domain/DomainEvent.cs
+++ b/src/Application/Domain/DomainEvent.cs
@@ -13,6 +13,9 @@ public abstract class DomainEvent : INotification
     {
         DateOccurred = DateTimeOffset.UtcNow;
     }
+
     public bool IsPublished { get; set; }
-    public DateTimeOffset DateOccurred { get; protected set; } = DateTime.UtcNow;
+
+    // Using DateTimeOffset to ensure timezone information is preserved
+    public DateTimeOffset DateOccurred { get; protected set; } = DateTimeOffset.UtcNow;
 }

--- a/tests/Application.Unit.Tests/Features/Products/EventHandlers/PriceChangedEventHandlerTests.cs
+++ b/tests/Application.Unit.Tests/Features/Products/EventHandlers/PriceChangedEventHandlerTests.cs
@@ -13,8 +13,9 @@ namespace Application.Unit.Tests.Features.Products.EventHandlers
         [Test]
         public void PriceChangedEvent_LoggerCalled()
         {
-            // Arrenge
-            var domainEvent = new ProductUpdatePriceEvent(It.IsAny<Product>());
+            // Arrange
+            var product = new Product(0, "Test", "Desc", 10, 1);
+            var domainEvent = new ProductUpdatePriceEvent(product);
             var handler = new PriceChangedEventHandler(Mock.Of<ILogger<PriceChangedEventHandler>>());
 
             // Act


### PR DESCRIPTION
## Summary
- update DomainEvent timestamp initialization
- fix unit test setup for `PriceChangedEventHandler`

## Testing
- `dotnet test --no-build` *(fails: command not found)*